### PR TITLE
replace address dedup logic with smart logic and interactive mode.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,21 @@ jobs:
 
   pyinstaller-build:
     # needs: [increment_version]
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            platform_name: 'Windows'
+            shell_cmd: 'dir'
+            zip_cmd: 'Compress-Archive -Path .\dist -DestinationPath .\Legoberry-${{ github.event.release.name }}-Windows.zip'
+            zip_shell: 'pwsh'
+          - os: macos-latest
+            platform_name: 'macOS'
+            shell_cmd: 'ls -la'
+            zip_cmd: 'zip -r Legoberry-${{ github.event.release.name }}-macOS.zip dist/'
+            zip_shell: 'bash'
+    
+    runs-on: ${{ matrix.os }}
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
@@ -37,6 +51,7 @@ jobs:
       - run: echo "${{ github.event.release.name }}"
       #- run: echo "new version is ${{ needs.increment_version.outputs.version }}"
       - run: echo "upload url is ${{ github.event.release.upload_url }}"
+      
       - name: Create Executable
         uses: sayyid5416/pyinstaller@v1
         id: create_exec
@@ -45,16 +60,18 @@ jobs:
           spec: 'legoberry.spec'
           requirements: 'requirements.txt'
           exe_path: ./dist
-          upload_exe_with_name: 'Legoberry-${{ github.event.release.name }}'
-          options: --onefile, --name "Legoberry-${{ github.event.release.name }}", --windowed,
-      - run: |
-          cd dist
-          dir
-      - name: Zip up dist
-        shell: pwsh
+          upload_exe_with_name: 'Legoberry-${{ github.event.release.name }}-${{ matrix.platform_name }}'
+          options: --onefile, --name "Legoberry-${{ github.event.release.name }}-${{ matrix.platform_name }}", --windowed,
+      
+      - name: List dist contents
         run: |
-          Compress-Archive -Path .\dist `
-                          -DestinationPath .\Legoberry-${{ github.event.release.name }}.zip
+          cd dist
+          ${{ matrix.shell_cmd }}
+      
+      - name: Create platform-specific archive
+        shell: ${{ matrix.zip_shell }}
+        run: ${{ matrix.zip_cmd }}
+      
       # - name: release
       #   uses: actions/create-release@v1
       #   id: create_release
@@ -66,12 +83,13 @@ jobs:
       #     body_path: CHANGELOG.md
       #   env:
       #     GITHUB_TOKEN: ${{ github.token }}
-      - name: upload windows artifact
+      
+      - name: Upload ${{ matrix.platform_name }} artifact
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: 'Legoberry-${{ github.event.release.name }}.zip'
-          asset_name: 'Legoberry-${{ github.event.release.name }}.zip'
+          asset_path: 'Legoberry-${{ github.event.release.name }}-${{ matrix.platform_name }}.zip'
+          asset_name: 'Legoberry-${{ github.event.release.name }}-${{ matrix.platform_name }}.zip'
           asset_content_type: application/zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,20 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.11']
+    
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -26,3 +31,14 @@ jobs:
       - name: Run tests
         run: |
           pytest tests/unit
+
+      - name: Test Interactive Features (Mock)
+        run: |
+          python -c "
+          import transformations
+          dedup = transformations.AddressDeduplicator()
+          result = dedup.smart_extract_address('123 Main St, Austin, TX 78701', 'Austin', 'TX', '78701')
+          assert result['result'] == '123 Main St'
+          assert 'city:Austin' in result['duplicates']
+          print('✅ Interactive features core logic works on ${{ matrix.os }}')
+          "

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,5 @@ jobs:
           result = dedup.smart_extract_address('123 Main St, Austin, TX 78701', 'Austin', 'TX', '78701')
           assert result['result'] == '123 Main St'
           assert 'city:Austin' in result['duplicates']
-          print('✅ Interactive features core logic works on ${{ matrix.os }}')
+          print('SUCCESS: Interactive features core logic works on ${{ matrix.os }}')
           "

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _note_: a period in the "parameter" field denotes a child item
 | smart_address_dedup | list of field names to check for address duplicates; intelligently removes city, state, zip duplicates from address fields | <pre>smart_address_dedup:<br>  - City<br>  - State<br>  - Zip</pre>|
 | dedup_action | defines how to handle detected address duplicates; works with `smart_address_dedup` | `"extract"` (auto-remove), `"flag_only"` (mark with %%%%), `"interactive"` (prompt user), or `"score_only"` (analyze only)|
 | confidence_threshold | minimum confidence percentage for automatic duplicate extraction; only used with `dedup_action: "extract"` | `70` (default), range: 0-100|
-| redundancy_threshold | minimum redundancy percentage to flag addresses as having duplicates | `20` (default), range: 0-100|
+| redundancy_threshold | minimum redundancy percentage to flag addresses as having duplicates | `10` (default), range: 0-100|
 | fields.replace.from| source data string to replace| 'Kindergarden Teacher'|
 | fields.replace.to | target string to replace the from string to| 'kinder'|
 | fields.default_value| new field to be created with hardcoded values. this only works if there is no source_name field specified| 'mch|

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ _note_: a period in the "parameter" field denotes a child item
 | fields.target_name | column name to rename to in the target file. must be in quotes | 'tag'|
 | fields.replace | list of different values in the data of this field to replace| <pre>replace:</br>  - from: 'Early Childhood Educator'</br>    to: 'prek'</pre>|
 | replace_with_file | allows you to pass in a file with the contents of 'replace'. makes the config easier to use. | my_file.yml|
-| remove_duplicates_from_fields | list of other field names to remove duplicate substrings from this field; removed parts are wrapped with `%%%%` markers for manual review | <pre>remove_duplicates_from_fields:<br>  - City<br>  - State/Province<br>  - Zip/Postal Code</pre>|
+| smart_address_dedup | list of field names to check for address duplicates; intelligently removes city, state, zip duplicates from address fields | <pre>smart_address_dedup:<br>  - City<br>  - State<br>  - Zip</pre>|
+| dedup_action | defines how to handle detected address duplicates; works with `smart_address_dedup` | `"extract"` (auto-remove), `"flag_only"` (mark with %%%%), `"interactive"` (prompt user), or `"score_only"` (analyze only)|
+| confidence_threshold | minimum confidence percentage for automatic duplicate extraction; only used with `dedup_action: "extract"` | `70` (default), range: 0-100|
+| redundancy_threshold | minimum redundancy percentage to flag addresses as having duplicates | `20` (default), range: 0-100|
 | fields.replace.from| source data string to replace| 'Kindergarden Teacher'|
 | fields.replace.to | target string to replace the from string to| 'kinder'|
 | fields.default_value| new field to be created with hardcoded values. this only works if there is no source_name field specified| 'mch|
@@ -35,6 +38,61 @@ _note_: a period in the "parameter" field denotes a child item
 |fields.split.index| if you split `martin licea` into 2, `martin` would be index 1 and `licea` would be index 2|2|
 |fields.split.target_name | name of new field to be created from the split| 'first|
 |max_target_file_size| the maximum number of rows the target file can contain. this will create multiple files if this number is smaller than the total aggregated rows.| 500 |
+
+## Smart Address Deduplication
+
+The smart address deduplication feature intelligently identifies and handles duplicate address components that users often enter in both the main address field and separate city/state/zip fields.
+
+### How It Works
+
+1. **Analysis**: Compares the address field against city, state, and zip fields
+2. **Scoring**: Calculates confidence (accuracy of extraction) and redundancy (% of duplicated content)
+3. **Processing**: Takes action based on `dedup_action` setting
+
+### Configuration Examples
+
+**Basic Setup:**
+```yaml
+- source_name: 'ADDRESS'
+  alias: 'address'
+  smart_address_dedup: ['City', 'State', 'Zip']
+  dedup_action: 'extract'
+```
+
+**Interactive Mode:**
+```yaml
+- source_name: 'ADDRESS' 
+  alias: 'address'
+  smart_address_dedup: ['City', 'State', 'Zip']
+  dedup_action: 'interactive'
+  confidence_threshold: 80
+  redundancy_threshold: 25
+```
+
+### Dedup Actions
+
+| Action | Behavior | Use Case |
+|--------|----------|----------|
+| `extract` | Automatically removes duplicates with high confidence | Clean, reliable data |
+| `flag_only` | Marks duplicates with `%%%%` for manual review | Want to review all changes |
+| `interactive` | Prompts user for decisions on each flagged address | Mixed data quality, need control |
+| `score_only` | Analyzes but makes no changes | Assessment/reporting only |
+
+### Interactive Mode Features
+
+When using `dedup_action: "interactive"`, you'll see:
+- **Field Values**: Shows the separate city/state/zip field contents
+- **Duplicate Detection**: Highlights which components are duplicated
+- **Confidence & Redundancy Scores**: Helps assess the extraction quality
+- **Multiple Options**: Keep original, use extracted, enter custom, or apply to all
+
+### Example Transformations
+
+| Original | City | State | Zip | Action | Result |
+|----------|------|-------|-----|--------|--------|
+| `123 Main St, Austin, TX 78701` | Austin | TX | 78701 | extract | `123 Main St` |
+| `456 Oak Ave, Dallas TX` | Dallas | TX | 75201 | extract | `456 Oak Ave` |
+| `789 Pine Rd, Houston` | Houston | TX | 77001 | flag_only | `%%%%789 Pine Rd, Houston%%%%` |
 
 
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -76,7 +76,43 @@
  - **email**: validates email addresses, preserving valid ones, flagging invalid ones with `%%%%…%%%%`,
    and converting empty strings to `None`.
 
-### test_remove_duplicates_from_fields
-Verifies that `transformations.remove_duplicates_from_fields` removes substrings from a target field
-based on values in specified other fields, wraps the modified field value with `%%%%` markers for review,
-and leaves entries without duplicates unchanged.
+## Smart Address Deduplication Tests
+
+### test_smart_address_dedup_extract_action
+Tests the smart address deduplication with `dedup_action: "extract"`. Verifies that duplicate city, state, and zip components are automatically removed from address fields when confidence and redundancy thresholds are met.
+
+### test_smart_address_dedup_flag_only_action
+Validates the `dedup_action: "flag_only"` behavior, ensuring addresses with duplicates are marked with `%%%%` markers for manual review without modifying the original content.
+
+### test_smart_address_dedup_score_only_action
+Confirms that `dedup_action: "score_only"` analyzes addresses for duplicates but makes no modifications to the original data.
+
+### test_smart_address_dedup_confidence_thresholds
+Tests the confidence threshold mechanism, verifying that only high-confidence extractions are automatically processed while lower-confidence cases are flagged with suggestions.
+
+### test_smart_address_dedup_redundancy_thresholds
+Validates that the redundancy threshold properly controls which addresses are flagged based on the percentage of duplicated content relative to the total address length.
+
+### test_smart_address_dedup_state_normalization
+Tests the state normalization feature, ensuring the system correctly handles both full state names (e.g., "Texas") and abbreviations (e.g., "TX") when detecting duplicates.
+
+### test_smart_address_dedup_edge_cases
+Covers edge cases including null addresses, empty strings, missing field values, and generic address components, ensuring the system handles these scenarios gracefully.
+
+### test_smart_address_dedup_missing_fields
+Verifies correct behavior when some of the specified deduplication fields don't exist in the DataFrame, processing only the available fields.
+
+### test_smart_address_dedup_no_config
+Confirms that the function returns unchanged data when no smart address deduplication configuration is provided.
+
+### test_smart_address_dedup_partial_config
+Tests behavior with incomplete configuration (missing required parameters), ensuring the system safely returns unchanged data.
+
+### test_smart_address_dedup_data_types
+Validates handling of different data types in address component fields, particularly integer zip codes that need string conversion.
+
+### test_smart_address_dedup_complex_addresses
+Tests complex address formats including apartments, suites, unit numbers, and extra components, ensuring important address details are preserved while duplicates are removed.
+
+### test_address_deduplicator_class
+Directly tests the `AddressDeduplicator` class methods including state normalization and smart address extraction, validating confidence scoring and duplicate detection logic.

--- a/config.yml
+++ b/config.yml
@@ -33,35 +33,42 @@ output_file_configs:
   - source_name: 'Address'
     alias: 'Address 1'
     casing: 'proper'
+    #remove_duplicates_from_fields:
+    #- 'City'
+    #- 'State'
+    #- 'Zip'
+    smart_address_dedup: ["City", "State", "Zip"]
+    dedup_action: "interactive"
+    mark_duplicates_only: false
     replace:
     - from: ','
       to: ''
-    - from: "[Dd]r($| )"
-      to: 'Dr.$1'
+    - from: "(?i)\bDr\b"
+      to: 'Dr.'
       is_expression: true
-    - from: '[aA]ve($| )'
-      to: ' Ave.$1'
+    - from: '(?i)\bAve\b'
+      to: 'Ave.'
       is_expression: true
-    - from: '[sS]t($| )'
-      to: ' St.$1'
+    - from: '(?i)\bSt\b'
+      to: 'St.'
       is_expression: true
-    - from: '[rR]d($| )'
-      to: ' Rd.$1'
+    - from: '(?i)\bRd\b'
+      to: 'Rd.'
       is_expression: true
-    - from: '[lL]n($| )'
-      to: ' Ln.$1'
+    - from: '(?i)\bLn\b'
+      to: 'Ln.'
       is_expression: true
-    - from: '[cC]t($| )'
-      to: ' Ct.$1'
+    - from: '(?i)\bCt\b'
+      to: 'Ct.'
       is_expression: true
-    - from: '[bB]lvd($| )'
-      to: ' Blvd.$1'
+    - from: '(?i)\bBlvd\b'
+      to: 'Blvd.'
       is_expression: true
-    - from: '[pP]kwy($| )'
-      to: ' Pkwy.$1'
+    - from: '(?i)\bPkwy\b'
+      to: 'Pkwy.'
       is_expression: true
-    - from: '[cC]ir($| )'
-      to: ' Cir.$1'
+    - from: '(?i)\bCir\b'
+      to: 'Cir.'
       is_expression: true
   - source_name: '\‘Address 2'
     alias: 'Address 2'

--- a/config.yml
+++ b/config.yml
@@ -38,8 +38,7 @@ output_file_configs:
     #- 'State'
     #- 'Zip'
     smart_address_dedup: ["City", "State", "Zip"]
-    dedup_action: "interactive"
-    mark_duplicates_only: false
+    dedup_action:  interactive #flag_only
     replace:
     - from: ','
       to: ''

--- a/legoberry.spec
+++ b/legoberry.spec
@@ -34,4 +34,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
+    icon=None,  # Cross-platform compatibility
 )

--- a/transformations.py
+++ b/transformations.py
@@ -10,6 +10,390 @@ logger = logging.getLogger(__name__)
 from pathlib import Path
 ic.configureOutput(contextAbsPath=True)
 
+# Interactive Address Deduplication Classes
+class InteractiveAddressProcessor:
+    def __init__(self):
+        self.user_decisions = {}  # Cache decisions for similar cases
+        self.apply_to_all = False
+        self.global_choice = None
+    
+    def display_comparison(self, original, extracted, city, state, zip_code, confidence, redundancy, field_values=None, duplicates_found=None):
+        """Display a clean comparison of the address options"""
+        print("\n" + "="*80)
+        print("ADDRESS DEDUPLICATION REVIEW")
+        print("="*80)
+        print(f"📍 Context: {city}, {state} {zip_code}")
+        print(f"📊 Confidence: {confidence}% | Redundancy: {redundancy}%")
+        print()
+        
+        # Show the separate field values being checked
+        if field_values:
+            print("📋 Field Values Being Checked:")
+            for field_name, field_value in field_values.items():
+                if field_value and str(field_value).strip() and str(field_value).lower() != "none":
+                    # Check if this field contains a duplicate
+                    is_duplicate = duplicates_found and any(dup.startswith(field_name.lower() + ":") for dup in duplicates_found)
+                    marker = " 🔄" if is_duplicate else ""
+                    print(f"   {field_name.title()}: '{field_value}'{marker}")
+            print()
+        
+        # Show which specific duplicates were found
+        if duplicates_found:
+            print("🔄 Duplicates Found in Address:")
+            for dup in duplicates_found:
+                if ":" in dup:
+                    field_type, value = dup.split(":", 1)
+                    print(f"   {field_type.title()}: '{value}'")
+            print()
+        
+        print(f"🔸 ORIGINAL:  '{original}'")
+        print(f"🔹 EXTRACTED: '{extracted}'")
+        print()
+    
+    def get_user_choice(self, original, extracted, city="", state="", zip_code="", confidence=0, redundancy=0, field_values=None, duplicates_found=None):
+        """Interactive prompt for user decision"""
+        
+        # Check if we have a cached decision for similar addresses
+        cache_key = f"{original}|{city}|{state}|{zip_code}"
+        if cache_key in self.user_decisions:
+            return self.user_decisions[cache_key]
+        
+        # Check if user chose "apply to all"
+        if self.apply_to_all and self.global_choice:
+            if self.global_choice == 'original':
+                return original
+            elif self.global_choice == 'extracted':
+                return extracted
+        
+        self.display_comparison(original, extracted, city, state, zip_code, confidence, redundancy, field_values, duplicates_found)
+        
+        while True:
+            print("Options:")
+            print("  [1] Keep original address")
+            print("  [2] Use extracted address") 
+            print("  [3] Enter custom address")
+            print("  [4] Apply choice to ALL remaining addresses")
+            print("  [s] Skip this address (keep original)")
+            print("  [q] Quit processing")
+            
+            try:
+                choice = input("\nYour choice (1-4, s, q): ").strip().lower()
+                
+                if choice in ['1', 's', '']:
+                    result = original
+                    break
+                elif choice == '2':
+                    result = extracted
+                    break
+                elif choice == '3':
+                    while True:
+                        custom = input("Enter custom address: ").strip()
+                        if custom:
+                            result = custom
+                            break
+                        else:
+                            print("Please enter a valid address.")
+                    break
+                elif choice == '4':
+                    # Apply to all
+                    print("\nWhat should be applied to ALL remaining addresses?")
+                    print("  [1] Keep all originals")
+                    print("  [2] Use all extractions")
+                    
+                    global_choice = input("Choice for all (1 or 2): ").strip()
+                    if global_choice == '1':
+                        self.apply_to_all = True
+                        self.global_choice = 'original'
+                        result = original
+                        break
+                    elif global_choice == '2':
+                        self.apply_to_all = True
+                        self.global_choice = 'extracted'
+                        result = extracted
+                        break
+                    else:
+                        print("Invalid choice. Please try again.")
+                        continue
+                elif choice == 'q':
+                    print("Quitting address processing...")
+                    result = original  # Default to original
+                    self.apply_to_all = True
+                    self.global_choice = 'original'
+                    break
+                else:
+                    print("Invalid choice. Please try again.")
+                    continue
+                    
+            except (KeyboardInterrupt, EOFError):
+                print("\n\nInterrupted. Keeping original address...")
+                result = original
+                break
+        
+        # Cache the decision
+        self.user_decisions[cache_key] = result
+        return result
+
+class AddressDeduplicator:
+    def __init__(self):
+        self.state_mappings = self._load_state_mappings()
+        self.abbrev_to_state = {v: k for k, v in self.state_mappings.items()}
+    
+    def _load_state_mappings(self):
+        """Load state mappings from states.yml if available, otherwise use defaults"""
+        try:
+            if Path("states.yml").exists():
+                with open("states.yml") as f:
+                    states_data = yaml.safe_load(f)
+                if isinstance(states_data, dict):
+                    return {k.lower(): v.lower() for k, v in states_data.items()}
+            # Fallback to common state mappings
+            return {
+                'alabama': 'al', 'alaska': 'ak', 'arizona': 'az', 'arkansas': 'ar', 'california': 'ca',
+                'colorado': 'co', 'connecticut': 'ct', 'delaware': 'de', 'florida': 'fl', 'georgia': 'ga',
+                'hawaii': 'hi', 'idaho': 'id', 'illinois': 'il', 'indiana': 'in', 'iowa': 'ia',
+                'kansas': 'ks', 'kentucky': 'ky', 'louisiana': 'la', 'maine': 'me', 'maryland': 'md',
+                'massachusetts': 'ma', 'michigan': 'mi', 'minnesota': 'mn', 'mississippi': 'ms',
+                'missouri': 'mo', 'montana': 'mt', 'nebraska': 'ne', 'nevada': 'nv', 'new hampshire': 'nh',
+                'new jersey': 'nj', 'new mexico': 'nm', 'new york': 'ny', 'north carolina': 'nc',
+                'north dakota': 'nd', 'ohio': 'oh', 'oklahoma': 'ok', 'oregon': 'or', 'pennsylvania': 'pa',
+                'rhode island': 'ri', 'south carolina': 'sc', 'south dakota': 'sd', 'tennessee': 'tn',
+                'texas': 'tx', 'utah': 'ut', 'vermont': 'vt', 'virginia': 'va', 'washington': 'wa',
+                'west virginia': 'wv', 'wisconsin': 'wi', 'wyoming': 'wy'
+            }
+        except Exception as e:
+            logger.warning(f"Could not load states.yml: {e}. Using defaults.")
+            return {}
+
+    def normalize_state(self, state_text: str) -> str:
+        """Normalize state to abbreviation format"""
+        if not state_text or str(state_text).lower() == "none":
+            return ""
+        state_clean = str(state_text or "").lower().strip()
+        if len(state_clean) == 2 and state_clean in self.abbrev_to_state:
+            return state_clean.upper()
+        if state_clean in self.state_mappings:
+            return self.state_mappings[state_clean].upper()
+        return state_text.upper()
+
+    def smart_extract_address(self, address: str, city: str = None, state: str = None, zip_code: str = None):
+        """Extract the core address by intelligently removing duplicates"""
+        if not address:
+            return {"result": "", "confidence": 0, "duplicates": []}
+        
+        duplicates = []
+        remaining = address.strip()
+        confidence = 100
+        
+        # Normalize inputs (convert to strings first)
+        city_norm = str(city or "").lower().strip() if city else ""
+        state_norm = self.normalize_state(str(state or "")) if state else ""
+        zip_norm = str(zip_code or "").strip() if zip_code else ""
+        
+        # Remove zip (most reliable)
+        if zip_norm and len(zip_norm) >= 4:
+            pattern = rf'\b{re.escape(zip_norm)}\b'
+            if re.search(pattern, remaining):
+                remaining = re.sub(pattern, '', remaining, flags=re.IGNORECASE)
+                duplicates.append(f"zip:{zip_norm}")
+        
+        # Remove state
+        if state_norm:
+            state_pattern = rf'\b{re.escape(state_norm)}\b'
+            if re.search(state_pattern, remaining, flags=re.IGNORECASE):
+                remaining = re.sub(state_pattern, '', remaining, flags=re.IGNORECASE)
+                duplicates.append(f"state:{state_norm}")
+            elif state_norm.lower() in self.abbrev_to_state:
+                full_state = self.abbrev_to_state[state_norm.lower()].title()
+                full_pattern = rf'\b{re.escape(full_state)}\b'
+                if re.search(full_pattern, remaining, flags=re.IGNORECASE):
+                    remaining = re.sub(full_pattern, '', remaining, flags=re.IGNORECASE)
+                    duplicates.append(f"state:{full_state}")
+        
+        # Remove city (careful - could be part of street name)
+        if city_norm and len(city_norm) > 2:
+            city_pattern = rf'\b{re.escape(city_norm)}\b'
+            matches = list(re.finditer(city_pattern, remaining, flags=re.IGNORECASE))
+            if matches:
+                last_match = matches[-1]
+                remaining = remaining[:last_match.start()] + remaining[last_match.end():]
+                duplicates.append(f"city:{city}")
+                if len(city_norm) < 5:
+                    confidence -= 20
+        
+        # Clean up result
+        result = re.sub(r'[,\s]+', ' ', remaining).strip(' ,.')
+        
+        # Adjust confidence
+        if len(duplicates) == 0:
+            confidence = 10
+        elif len(result) < 5:
+            confidence = 30
+        
+        return {
+            "result": result,
+            "confidence": confidence,
+            "duplicates": duplicates
+        }
+
+def smart_address_deduplication(df: pl.DataFrame, field: dict) -> pl.DataFrame:
+    """
+    SMART ADDRESS DEDUPLICATION with Interactive Mode
+    
+    Configuration options:
+    - smart_address_dedup: list of fields to check for duplicates  
+    - dedup_action: "extract", "flag_only", "interactive", or "score_only"
+    - confidence_threshold: minimum confidence to auto-extract (default: 70)
+    - redundancy_threshold: minimum redundancy % to flag (default: 20)
+    """
+    remove_fields = field.get("smart_address_dedup", [])
+    action = field.get("dedup_action", "extract")
+    confidence_threshold = field.get("confidence_threshold", 70)
+    redundancy_threshold = field.get("redundancy_threshold", 20)
+    
+    if not remove_fields:
+        return df
+    
+    alias = field.get("alias")
+    source = field.get("source_name")
+    field_name = alias if alias else source
+    
+    if field_name not in df.columns:
+        return df
+    
+    valid_fields = [f for f in remove_fields if f in df.columns]
+    if not valid_fields:
+        return df
+    
+    deduplicator = AddressDeduplicator()
+    
+    # Collect addresses for interactive review (only if action is "interactive")
+    addresses_for_review = []
+    decisions = {}
+    
+    # First pass: identify addresses that need review
+    for row in df.iter_rows(named=True):
+        address = row[field_name]
+        if not isinstance(address, str):
+            continue
+            
+        # Get field values (convert to strings)
+        field_values = {f.lower(): str(row.get(f, "") or "") for f in valid_fields}
+        city = field_values.get("city", "")
+        state = field_values.get("state", field_values.get("state/province", ""))
+        zip_code = field_values.get("zip", field_values.get("zip/postal code", ""))
+        
+        # Check for duplicates
+        extraction = deduplicator.smart_extract_address(address, city, state, zip_code)
+        total_chars = len(address)
+        duplicate_chars = sum(len(dup.split(":", 1)[1]) for dup in extraction["duplicates"] if ":" in dup)
+        redundancy_score = round((duplicate_chars / total_chars) * 100, 1) if total_chars > 0 else 0
+        
+        # Check if needs interactive review (only for "interactive" action)
+        if (action == "interactive" and 
+            extraction["duplicates"] and 
+            redundancy_score >= redundancy_threshold):
+            
+            # Store all field values for display
+            field_display_values = {}
+            for field_name in valid_fields:
+                field_display_values[field_name.lower()] = field_values.get(field_name.lower(), "")
+            
+            addresses_for_review.append({
+                "address": address,
+                "extracted": extraction["result"],
+                "city": city,
+                "state": state,
+                "zip": zip_code,
+                "confidence": extraction["confidence"],
+                "redundancy": redundancy_score,
+                "field_values": field_display_values,
+                "duplicates": extraction["duplicates"]
+            })
+    
+    # Interactive review process (only if action is "interactive")
+    if addresses_for_review and action == "interactive":
+        print(f"\n🔍 Found {len(addresses_for_review)} addresses with potential duplicates.")
+        print("Starting interactive review...\n")
+        
+        processor = InteractiveAddressProcessor()
+        
+        for i, addr_data in enumerate(addresses_for_review):
+            print(f"\nProgress: {i+1}/{len(addresses_for_review)}")
+            
+            # Prepare field values for display
+            display_fields = addr_data.get("field_values", {})
+            
+            decision = processor.get_user_choice(
+                addr_data["address"],
+                addr_data["extracted"], 
+                addr_data["city"],
+                addr_data["state"],
+                addr_data["zip"],
+                addr_data["confidence"],
+                addr_data["redundancy"],
+                display_fields,
+                addr_data.get("duplicates", [])
+            )
+            
+            decisions[addr_data["address"]] = decision
+        
+        print(f"\n✅ Interactive review completed! Processed {len(decisions)} addresses.")
+    
+    # Apply decisions
+    def process_address(row):
+        address = row[field_name]
+        if not isinstance(address, str):
+            return address
+        
+        # Check for interactive decision first
+        if address in decisions:
+            return decisions[address]
+        
+        # Process based on action type
+        field_values = {f.lower(): str(row.get(f, "") or "") for f in valid_fields}
+        city = field_values.get("city", "")
+        state = field_values.get("state", field_values.get("state/province", ""))
+        zip_code = field_values.get("zip", field_values.get("zip/postal code", ""))
+        
+        extraction = deduplicator.smart_extract_address(address, city, state, zip_code)
+        total_chars = len(address)
+        duplicate_chars = sum(len(dup.split(":", 1)[1]) for dup in extraction["duplicates"] if ":" in dup)
+        redundancy_score = round((duplicate_chars / total_chars) * 100, 1) if total_chars > 0 else 0
+        
+        if action == "score_only":
+            # Just analyze, don't modify
+            return address
+            
+        elif action == "flag_only":
+            # Flag duplicates for manual review
+            if extraction["duplicates"] and redundancy_score >= redundancy_threshold:
+                return f"%%%%{address}%%%%"
+            return address
+            
+        elif action in ["extract", "interactive"]:
+            # Smart extraction (auto for "extract", fallback for "interactive")
+            if extraction["confidence"] >= confidence_threshold and redundancy_score >= redundancy_threshold:
+                return extraction["result"]
+            elif redundancy_score >= redundancy_threshold:
+                return f"%%%%{address}%%%% [SUGGEST: {extraction['result']}]"
+            else:
+                return address
+        
+        return address
+    
+    # Apply processing to each row
+    processed_addresses = []
+    for row in df.iter_rows(named=True):
+        processed_address = process_address(row)
+        processed_addresses.append(processed_address)
+    
+    # Update the DataFrame with processed addresses
+    df = df.with_columns(
+        pl.Series(processed_addresses).alias(field_name)
+    )
+    
+    return df
+
 def do_explore(conifg, df):
     pass
 
@@ -183,44 +567,30 @@ def validate_against_list(df: pl.DataFrame, field: dict) -> pl.DataFrame:
     return df
 def remove_duplicates_from_fields(df: pl.DataFrame, field: dict) -> pl.DataFrame:
     """
-    Remove duplicate substrings from a field based on values in other fields.
-    If any duplicates are removed, wrap the result with %%%% markers.
+    Smart Address Deduplication Function
+    
+    This function intelligently removes duplicate address components (city, state, zip) 
+    from address fields based on separate field values.
+    
+    Configuration:
+    - smart_address_dedup: list of fields to check for duplicates (e.g., ["City", "State", "Zip"])
+    - dedup_action: how to handle duplicates
+        * "extract": automatically remove duplicates with high confidence
+        * "flag_only": mark addresses with duplicates using %%%% markers
+        * "interactive": prompt user for decisions on each flagged address
+        * "score_only": analyze only, no modifications
+    - confidence_threshold: minimum confidence for auto-extraction (default: 70)
+    - redundancy_threshold: minimum redundancy % to flag addresses (default: 20)
     """
-    remove_fields = field.get("remove_duplicates_from_fields", [])
-    if not remove_fields:
-        return df
-    alias = field.get("alias")
-    source = field.get("source_name")
-    field_name = alias if alias else source
-    if field_name not in df.columns:
-        return df
-    valid_remove_fields = [f for f in remove_fields if f in df.columns]
-    if not valid_remove_fields:
-        return df
-    def _remove_duplicates(row):
-        addr = row[field_name]
-        if not isinstance(addr, str):
-            return addr
-        modified = False
-        # Remove each duplicate value along with surrounding commas/spaces
-        for dup in valid_remove_fields:
-            val = row[dup]
-            if val and isinstance(val, str) and re.search(re.escape(val), addr, flags=re.IGNORECASE):
-                pattern = rf"[\s,\.]*(?:\b{re.escape(val)}\b)[\s,\.]*"
-                matches = list(re.finditer(pattern, addr, flags=re.IGNORECASE))
-                if matches:
-                    last = matches[-1]
-                    addr = addr[:last.start()] + " " + addr[last.end():]
-                    modified = True
-        if modified:
-            addr = re.sub(r"\s+", " ", addr).strip(", .")
-            return f"%%%%{addr}%%%%"
-        return addr
-    df = df.with_columns(
-        pl.struct([field_name] + valid_remove_fields)
-          .apply(_remove_duplicates)
-          .alias(field_name)
-    )
+    # Check for smart address deduplication parameters
+    smart_fields = field.get("smart_address_dedup", [])
+    dedup_action = field.get("dedup_action", None)
+    
+    # Only proceed if using smart address deduplication
+    if smart_fields and dedup_action:
+        return smart_address_deduplication(df, field)
+    
+    # Return unchanged if no smart deduplication configured
     return df
 
 def select_columns(df: pl.DataFrame, field: dict) -> pl.DataFrame:

--- a/transformations.py
+++ b/transformations.py
@@ -80,13 +80,13 @@ class InteractiveAddressProcessor:
         self.display_comparison(original, extracted, city, state, zip_code, confidence, redundancy, field_values, duplicates_found)
         
         while True:
-            print("Options:")
-            print("  [1] Keep original address")
-            print("  [2] Use extracted address") 
-            print("  [3] Enter custom address")
-            print("  [4] Apply choice to ALL remaining addresses")
-            print("  [s] Skip this address (keep original)")
-            print("  [q] Quit processing")
+            safe_print("Options:")
+            safe_print("  [1] Keep original address")
+            safe_print("  [2] Use extracted address") 
+            safe_print("  [3] Enter custom address")
+            safe_print("  [4] Apply choice to ALL remaining addresses")
+            safe_print("  [s] Skip this address (keep original)")
+            safe_print("  [q] Quit processing")
             
             try:
                 choice = input("\nYour choice (1-4, s, q): ").strip().lower()
@@ -104,13 +104,13 @@ class InteractiveAddressProcessor:
                             result = custom
                             break
                         else:
-                            print("Please enter a valid address.")
+                            safe_print("Please enter a valid address.")
                     break
                 elif choice == '4':
                     # Apply to all
-                    print("\nWhat should be applied to ALL remaining addresses?")
-                    print("  [1] Keep all originals")
-                    print("  [2] Use all extractions")
+                    safe_print("\nWhat should be applied to ALL remaining addresses?")
+                    safe_print("  [1] Keep all originals")
+                    safe_print("  [2] Use all extractions")
                     
                     global_choice = input("Choice for all (1 or 2): ").strip()
                     if global_choice == '1':
@@ -124,20 +124,16 @@ class InteractiveAddressProcessor:
                         result = extracted
                         break
                     else:
-                        print("Invalid choice. Please try again.")
-                        continue
+                        safe_print("Invalid choice. Please try again.")
                 elif choice == 'q':
-                    print("Quitting address processing...")
-                    result = original  # Default to original
-                    self.apply_to_all = True
-                    self.global_choice = 'original'
-                    break
+                    safe_print("Quitting address processing...")
+                    import sys
+                    sys.exit(0)
                 else:
-                    print("Invalid choice. Please try again.")
-                    continue
+                    safe_print("Invalid choice. Please try again.")
                     
-            except (KeyboardInterrupt, EOFError):
-                print("\n\nInterrupted. Keeping original address...")
+            except KeyboardInterrupt:
+                safe_print("\n\nInterrupted. Keeping original address...")
                 result = original
                 break
         


### PR DESCRIPTION
This PR introduces a comprehensive smart address deduplication system that replaces the legacy remove_duplicates_from_fields functionality with an intelligent, configurable, and user-friendly approach to handling duplicate address components.

Smart Address Analysis
Intelligent Detection: Automatically identifies when city, state, and zip components appear in both the main address field and separate component fields
Confidence Scoring: Calculates extraction confidence based on exact matches, partial matches, and address structure
Redundancy Scoring: Measures the percentage of duplicated content relative to total address length
State Normalization: Handles both full state names ("Texas") and abbreviations ("TX") for accurate matching
Flexible Processing Actions
extract: Automatically removes duplicates with high confidence
flag_only: Marks addresses with duplicates using %%%% markers for manual review
interactive: Prompts user for decisions on each flagged address with enhanced display
score_only: Analyzes addresses without making modifications

```
smart_address_dedup: ["City", "State", "Zip"]      # Fields to check for duplicates
dedup_action: "interactive"                         # How to handle duplicates
confidence_threshold: 70                            # Min confidence for auto-extraction
redundancy_threshold: 20     ```